### PR TITLE
Add ability to use Jenkins Crumb for CSRF protection setting

### DIFF
--- a/src/JenkinsNetClient/JenkinsConnection.cs
+++ b/src/JenkinsNetClient/JenkinsConnection.cs
@@ -55,6 +55,20 @@
         /// Initializes a new instance of the <see cref="JenkinsConnection" /> class.
         /// </summary>
         /// <param name="url">the target jenkins server url</param>
+        /// <param name="username">the jenkins username</param>
+        /// <param name="apiToken">the jenkins API token</param>
+        public JenkinsConnection(string url, string username, string apiToken)
+        {
+            this.url = url;
+            this.username = username;
+            this.apiToken = apiToken;
+            this.crumb = crumb;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JenkinsConnection" /> class.
+        /// </summary>
+        /// <param name="url">the target jenkins server url</param>
         /// <param name="crumb">the jenkins crumb</param>
         public JenkinsConnection(string url, string crumb)
         {

--- a/src/JenkinsNetClient/JenkinsConnection.cs
+++ b/src/JenkinsNetClient/JenkinsConnection.cs
@@ -25,6 +25,11 @@
         private readonly string apiToken;
 
         /// <summary>
+        /// Holds the jenkins crumb
+        /// </summary>
+        private readonly string crumb;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="JenkinsConnection" /> class.
         /// </summary>
         /// <param name="url">the target jenkins server url</param>
@@ -47,6 +52,17 @@
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="JenkinsConnection" /> class.
+        /// </summary>
+        /// <param name="url">the target jenkins server url</param>
+        /// <param name="crumb">the jenkins crumb</param>
+        public JenkinsConnection(string url, string crumb)
+        {
+            this.url = url;
+            this.crumb = crumb;
+        }
+
+        /// <summary>
         /// Make a GET request to jenkins.
         /// </summary>
         /// <remarks>Content Type is <c>text/json</c></remarks>
@@ -60,7 +76,8 @@
                         new JsonRequest(
                             new HttpRequest(this.url, command))),
                     this.username,
-                    this.apiToken));
+                    this.apiToken,
+                    this.crumb));
         }
 
         /// <summary>
@@ -79,7 +96,8 @@
                             new HttpRequest(this.url, command),
                             postData),
                         this.username,
-                        this.apiToken),
+                        this.apiToken,
+                        this.crumb),
                     contentType));
         }
 

--- a/src/JenkinsNetClient/Request/AuthorisedRequest.cs
+++ b/src/JenkinsNetClient/Request/AuthorisedRequest.cs
@@ -54,7 +54,7 @@
                 string base64Credentials = System.Convert.ToBase64String(byteCredentials);
                 req.Headers.Add("Authorization", "Basic " + base64Credentials);
             }
-            else if (!string.IsNullOrEmpty(this.crumb))
+            if (!string.IsNullOrEmpty(this.crumb))
             {
                 req.Headers.Add("Jenkins-Crumb", crumb);
             }

--- a/src/JenkinsNetClient/Request/AuthorisedRequest.cs
+++ b/src/JenkinsNetClient/Request/AuthorisedRequest.cs
@@ -21,16 +21,22 @@
         private readonly string apiToken;
 
         /// <summary>
+        /// Holds the crumb
+        /// </summary>
+        private readonly string crumb;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="AuthorisedRequest"/> class.
         /// </summary>
         /// <param name="request">The request<see cref="IRequest"/></param>
         /// <param name="username">The username<see cref="string"/></param>
         /// <param name="apiToken">The API token<see cref="string"/></param>
-        public AuthorisedRequest(IRequest request, string username, string apiToken)
+        public AuthorisedRequest(IRequest request, string username, string apiToken, string crumb)
         {
             this.origin = request;
             this.username = username;
             this.apiToken = apiToken;
+            this.crumb = crumb;
         }
 
         /// <summary>
@@ -47,6 +53,10 @@
                 byte[] byteCredentials = System.Text.UTF8Encoding.UTF8.GetBytes(mergedCredentials);
                 string base64Credentials = System.Convert.ToBase64String(byteCredentials);
                 req.Headers.Add("Authorization", "Basic " + base64Credentials);
+            }
+            else if (!string.IsNullOrEmpty(this.crumb))
+            {
+                req.Headers.Add("Jenkins-Crumb", crumb);
             }
 
             return req;


### PR DESCRIPTION
https://wiki.jenkins.io/display/JENKINS/Remote+access+API#RemoteaccessAPI-CSRFProtection

To work with Jenkins when "Prevent Cross Site Request Forgery exploits" setting is enabled, allow using the crumb for requests both with and without username/token combo. Crumbs are obtained from the /crumbIssuer/api/xml endpoint.

Example of new usage in VB:
Dim connection As JenkinsConnection = New JenkinsConnection("http://jenkins-url", "jenkins-crumb")
or
Dim connection As JenkinsConnection = New JenkinsConnection("http://jenkins-url", "username", "token", "jenkins-crumb")

A "Jenkins-Crumb" header is added to the request when the crumb is specified.