### PR TITLE
Add ability to use Jenkins Crumb for CSRF protection setting and add ability to run a Jenkins build with parameters

### DIFF
--- a/src/JenkinsNetClient/JenkinsConnection.cs
+++ b/src/JenkinsNetClient/JenkinsConnection.cs
@@ -55,6 +55,20 @@
         /// Initializes a new instance of the <see cref="JenkinsConnection" /> class.
         /// </summary>
         /// <param name="url">the target jenkins server url</param>
+        /// <param name="username">the jenkins username</param>
+        /// <param name="apiToken">the jenkins API token</param>
+        public JenkinsConnection(string url, string username, string apiToken)
+        {
+            this.url = url;
+            this.username = username;
+            this.apiToken = apiToken;
+            this.crumb = crumb;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JenkinsConnection" /> class.
+        /// </summary>
+        /// <param name="url">the target jenkins server url</param>
         /// <param name="crumb">the jenkins crumb</param>
         public JenkinsConnection(string url, string crumb)
         {

--- a/src/JenkinsNetClient/JenkinsConnection.cs
+++ b/src/JenkinsNetClient/JenkinsConnection.cs
@@ -25,6 +25,11 @@
         private readonly string apiToken;
 
         /// <summary>
+        /// Holds the jenkins crumb
+        /// </summary>
+        private readonly string crumb;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="JenkinsConnection" /> class.
         /// </summary>
         /// <param name="url">the target jenkins server url</param>
@@ -47,6 +52,17 @@
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="JenkinsConnection" /> class.
+        /// </summary>
+        /// <param name="url">the target jenkins server url</param>
+        /// <param name="crumb">the jenkins crumb</param>
+        public JenkinsConnection(string url, string crumb)
+        {
+            this.url = url;
+            this.crumb = crumb;
+        }
+
+        /// <summary>
         /// Make a GET request to jenkins.
         /// </summary>
         /// <remarks>Content Type is <c>text/json</c></remarks>
@@ -60,7 +76,8 @@
                         new JsonRequest(
                             new HttpRequest(this.url, command))),
                     this.username,
-                    this.apiToken));
+                    this.apiToken,
+                    this.crumb));
         }
 
         /// <summary>
@@ -79,7 +96,8 @@
                             new HttpRequest(this.url, command),
                             postData),
                         this.username,
-                        this.apiToken),
+                        this.apiToken,
+                        this.crumb),
                     contentType));
         }
 

--- a/src/JenkinsNetClient/JenkinsConnection.cs
+++ b/src/JenkinsNetClient/JenkinsConnection.cs
@@ -57,7 +57,7 @@
         /// <param name="url">the target jenkins server url</param>
         /// <param name="username">the jenkins username</param>
         /// <param name="apiToken">the jenkins API token</param>
-        public JenkinsConnection(string url, string username, string apiToken)
+        public JenkinsConnection(string url, string username, string apiToken, string crumb)
         {
             this.url = url;
             this.username = username;

--- a/src/JenkinsNetClient/JenkinsItem.cs
+++ b/src/JenkinsNetClient/JenkinsItem.cs
@@ -26,6 +26,11 @@
         private readonly string deleteCommand;
 
         /// <summary>
+        /// Defines the buildCommand
+        /// </summary>
+        private readonly string buildCommand;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="JenkinsItem"/> class.
         /// </summary>
         /// <param name="jenkinsConnection">The jenkinsConnection<see cref="IJenkinsConnection"/></param>
@@ -34,13 +39,15 @@
         /// <param name="existsCommand">The command for exist check<see cref="string"/></param>
         /// <param name="createCommand">The command for create<see cref="string"/></param>
         /// <param name="deleteCommand">The command for delete<see cref="string"/></param>
+        /// <param name="buildcommand">The command for build<see cref="string"/></param>
         protected JenkinsItem(
             IJenkinsConnection jenkinsConnection,
             string model,
             string name,
             string existsCommand,
             string createCommand,
-            string deleteCommand)
+            string deleteCommand,
+            string buildCommand)
         {
             this.JenkinsConnection = jenkinsConnection;
             this.Model = model;
@@ -48,6 +55,7 @@
             this.existsCommand = existsCommand;
             this.createCommand = createCommand;
             this.deleteCommand = deleteCommand;
+            this.buildCommand = buildCommand;
         }
 
         /// <summary>
@@ -101,6 +109,24 @@
             {
                 return this.JenkinsConnection.TryPost(
                     this.deleteCommand,
+                    "application/x-www-form-urlencoded",
+                    string.Empty);
+            }
+
+            return !failIfNotExists;
+        }
+
+        /// <summary>
+        /// Starts a build for this job on jenkins, if it exists
+        /// </summary>
+        /// <param name="failIfNotExists">flag to indicate return value if job doesn't exist</param>
+        /// <returns>true if job has executed, false if execution failed. If job doesn't exist return !<c>failIfNotExists</c></returns>
+        public bool Build(bool failIfNotExists = false)
+        {
+            if (this.Exists)
+            {
+                return this.JenkinsConnection.TryPost(
+                    this.buildCommand,
                     "application/x-www-form-urlencoded",
                     string.Empty);
             }

--- a/src/JenkinsNetClient/JenkinsItem.cs
+++ b/src/JenkinsNetClient/JenkinsItem.cs
@@ -132,8 +132,7 @@ namespace JenkinsNetClient
                 {
                     if (queryString != "?")
                         queryString += "&";
-                    queryString += System.Uri.EscapeDataString(parameter.Key);
-                    queryString += System.Uri.EscapeDataString(parameter.Value);
+                    queryString += $"{System.Uri.EscapeDataString(parameter.Key)}={System.Uri.EscapeDataString(parameter.Value)}";
                 }
                 return this.JenkinsConnection.TryPost(
                     this.buildCommand + queryString,

--- a/src/JenkinsNetClient/JenkinsItem.cs
+++ b/src/JenkinsNetClient/JenkinsItem.cs
@@ -1,4 +1,6 @@
-﻿namespace JenkinsNetClient
+﻿using System.Collections.Generic;
+
+namespace JenkinsNetClient
 {
     /// <summary>
     /// Defines the <see cref="JenkinsItem" />
@@ -121,12 +123,20 @@
         /// </summary>
         /// <param name="failIfNotExists">flag to indicate return value if job doesn't exist</param>
         /// <returns>true if job has executed, false if execution failed. If job doesn't exist return !<c>failIfNotExists</c></returns>
-        public bool Build(bool failIfNotExists = false)
+        public bool BuildWithParameters(Dictionary<string, string> parameters,  bool failIfNotExists = false)
         {
             if (this.Exists)
             {
+                string queryString = "?";
+                foreach (KeyValuePair<string, string> parameter in parameters)
+                {
+                    if (queryString != "?")
+                        queryString += "&";
+                    queryString += System.Uri.EscapeDataString(parameter.Key);
+                    queryString += System.Uri.EscapeDataString(parameter.Value);
+                }
                 return this.JenkinsConnection.TryPost(
-                    this.buildCommand,
+                    this.buildCommand + queryString,
                     "application/x-www-form-urlencoded",
                     string.Empty);
             }

--- a/src/JenkinsNetClient/JenkinsJob.cs
+++ b/src/JenkinsNetClient/JenkinsJob.cs
@@ -21,7 +21,7 @@
                   string.Format("/checkJobName?value={0}", name),
                   string.Format("/createItem?name={0}&mode={1}", name, model),
                   string.Format("/job/{0}/doDelete", name),
-                  string.Format("/job/{0}/build", name))
+                  string.Format("/job/{0}/buildWithParameters", name))
         {
         }
 

--- a/src/JenkinsNetClient/JenkinsJob.cs
+++ b/src/JenkinsNetClient/JenkinsJob.cs
@@ -20,7 +20,8 @@
                   name,
                   string.Format("/checkJobName?value={0}", name),
                   string.Format("/createItem?name={0}&mode={1}", name, model),
-                  string.Format("/job/{0}/doDelete", name))
+                  string.Format("/job/{0}/doDelete", name),
+                  string.Format("/job/{0}/build", name))
         {
         }
 

--- a/src/JenkinsNetClient/JenkinsView.cs
+++ b/src/JenkinsNetClient/JenkinsView.cs
@@ -21,7 +21,8 @@
                   name,
                   string.Format("/viewExistsCheck?value={0}", name),
                   string.Format("/createView?name={0}&mode={1}", name, model),
-                  string.Format("/view/{0}/doDelete", name))
+                  string.Format("/view/{0}/doDelete", name),
+                  string.Format("/job/{0}/build", name))
         {
         }
 

--- a/src/JenkinsNetClient/JenkinsView.cs
+++ b/src/JenkinsNetClient/JenkinsView.cs
@@ -22,7 +22,7 @@
                   string.Format("/viewExistsCheck?value={0}", name),
                   string.Format("/createView?name={0}&mode={1}", name, model),
                   string.Format("/view/{0}/doDelete", name),
-                  string.Format("/job/{0}/build", name))
+                  string.Format("/job/{0}/buildWithParameters", name))
         {
         }
 

--- a/src/JenkinsNetClient/Request/AuthorisedRequest.cs
+++ b/src/JenkinsNetClient/Request/AuthorisedRequest.cs
@@ -54,7 +54,7 @@
                 string base64Credentials = System.Convert.ToBase64String(byteCredentials);
                 req.Headers.Add("Authorization", "Basic " + base64Credentials);
             }
-            else if (!string.IsNullOrEmpty(this.crumb))
+            if (!string.IsNullOrEmpty(this.crumb))
             {
                 req.Headers.Add("Jenkins-Crumb", crumb);
             }

--- a/src/JenkinsNetClient/Request/AuthorisedRequest.cs
+++ b/src/JenkinsNetClient/Request/AuthorisedRequest.cs
@@ -31,6 +31,19 @@
         /// <param name="request">The request<see cref="IRequest"/></param>
         /// <param name="username">The username<see cref="string"/></param>
         /// <param name="apiToken">The API token<see cref="string"/></param>
+        public AuthorisedRequest(IRequest request, string username, string apiToken)
+        {
+            this.origin = request;
+            this.username = username;
+            this.apiToken = apiToken;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthorisedRequest"/> class.
+        /// </summary>
+        /// <param name="request">The request<see cref="IRequest"/></param>
+        /// <param name="username">The username<see cref="string"/></param>
+        /// <param name="apiToken">The API token<see cref="string"/></param>
         public AuthorisedRequest(IRequest request, string username, string apiToken, string crumb)
         {
             this.origin = request;

--- a/src/JenkinsNetClient/Request/AuthorisedRequest.cs
+++ b/src/JenkinsNetClient/Request/AuthorisedRequest.cs
@@ -21,16 +21,22 @@
         private readonly string apiToken;
 
         /// <summary>
+        /// Holds the crumb
+        /// </summary>
+        private readonly string crumb;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="AuthorisedRequest"/> class.
         /// </summary>
         /// <param name="request">The request<see cref="IRequest"/></param>
         /// <param name="username">The username<see cref="string"/></param>
         /// <param name="apiToken">The API token<see cref="string"/></param>
-        public AuthorisedRequest(IRequest request, string username, string apiToken)
+        public AuthorisedRequest(IRequest request, string username, string apiToken, string crumb)
         {
             this.origin = request;
             this.username = username;
             this.apiToken = apiToken;
+            this.crumb = crumb;
         }
 
         /// <summary>
@@ -47,6 +53,10 @@
                 byte[] byteCredentials = System.Text.UTF8Encoding.UTF8.GetBytes(mergedCredentials);
                 string base64Credentials = System.Convert.ToBase64String(byteCredentials);
                 req.Headers.Add("Authorization", "Basic " + base64Credentials);
+            }
+            else if (!string.IsNullOrEmpty(this.crumb))
+            {
+                req.Headers.Add("Jenkins-Crumb", crumb);
             }
 
             return req;


### PR DESCRIPTION
https://wiki.jenkins.io/display/JENKINS/Remote+access+API#RemoteaccessAPI-CSRFProtection

To work with Jenkins when "Prevent Cross Site Request Forgery exploits" setting is enabled, allow using the crumb for requests both with and without username/token combo. Crumbs are obtained from the /crumbIssuer/api/xml endpoint.

Example of new usage in VB:
Dim connection As JenkinsConnection = New JenkinsConnection("http://jenkins-url", "jenkins-crumb")
or
Dim connection As JenkinsConnection = New JenkinsConnection("http://jenkins-url", "username", "token", "jenkins-crumb")

A "Jenkins-Crumb" header is added to the request when the crumb is specified.

-------

A build can also be run by calling BuildWithParameters on a job.