### PR TITLE
 Add ability to use Jenkins Crumb for CSRF protection setting and add ability to run a Jenkins build with parameters

### DIFF
--- a/src/JenkinsNetClient/JenkinsConnection.cs
+++ b/src/JenkinsNetClient/JenkinsConnection.cs
@@ -2,6 +2,7 @@
 {
     using System.IO;
     using System.Net;
+    using System.Xml;
     using JenkinsNetClient.Request;
 
     /// <summary>
@@ -25,11 +26,21 @@
         private readonly string apiToken;
 
         /// <summary>
+        /// Holds the jenkins crumb
+        /// </summary>
+        private readonly string crumb;
+
+        /// <summary>
+        /// Determines if crumb should be automatically retrieved
+        /// </summary>
+        private readonly bool autoRetrieveCrumb;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="JenkinsConnection" /> class.
         /// </summary>
         /// <param name="url">the target jenkins server url</param>
-        public JenkinsConnection(string url)
-            : this(url, null, null)
+        public JenkinsConnection(string url, bool autoRetrieveCrumb = false)
+            : this(url, null, null, autoRetrieveCrumb)
         {
         }
 
@@ -47,6 +58,63 @@
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="JenkinsConnection" /> class.
+        /// </summary>
+        /// <param name="url">the target jenkins server url</param>
+        /// <param name="username">the jenkins username</param>
+        /// <param name="apiToken">the jenkins API token</param>
+        /// <param name="crumb">the jenkins crumb</param>
+        public JenkinsConnection(string url, string username, string apiToken, string crumb)
+        {
+            this.url = url;
+            this.username = username;
+            this.apiToken = apiToken;
+            this.crumb = crumb;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JenkinsConnection" /> class.
+        /// </summary>
+        /// <param name="url">the target jenkins server url</param>
+        /// <param name="username">the jenkins username</param>
+        /// <param name="apiToken">the jenkins API token</param>
+        /// <param name="autoRetrieveCrumb">determines if the crumb will be automatically retrieved</param>
+        public JenkinsConnection(string url, string username, string apiToken, bool autoRetrieveCrumb)
+        {
+            this.url = url;
+            this.username = username;
+            this.apiToken = apiToken;
+            this.autoRetrieveCrumb = autoRetrieveCrumb;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JenkinsConnection" /> class.
+        /// </summary>
+        /// <param name="url">the target jenkins server url</param>
+        /// <param name="crumb">the jenkins crumb</param>
+        public JenkinsConnection(string url, string crumb)
+        {
+            this.url = url;
+            this.crumb = crumb;
+        }
+
+        /// <summary>
+        /// Get a crumb from jenkins.
+        /// </summary>
+        /// <returns>the crumb</returns>
+        private string RetrieveCrumb()
+        {
+            var crumbXml = this.CallRequest(
+                    new GetRequest(
+                        new XmlRequest(
+                            new HttpRequest(this.url, "/crumbIssuer/api/xml"))));
+            XmlDocument crumbDoc = new XmlDocument();
+            crumbDoc.LoadXml(crumbXml);
+            XmlNode requestedCrumb = crumbDoc.SelectSingleNode("defaultCrumbIssuer/crumb");
+            return requestedCrumb.InnerText;
+        }
+
+        /// <summary>
         /// Make a GET request to jenkins.
         /// </summary>
         /// <remarks>Content Type is <c>text/json</c></remarks>
@@ -54,13 +122,19 @@
         /// <returns>the response from the jenkins server</returns>
         public string Get(string command)
         {
+            string crumb = this.crumb;
+            if (this.autoRetrieveCrumb)
+            {
+                crumb = RetrieveCrumb();
+            }
             return this.CallRequest(
                 new AuthorisedRequest(
                     new GetRequest(
                         new JsonRequest(
                             new HttpRequest(this.url, command))),
                     this.username,
-                    this.apiToken));
+                    this.apiToken,
+                    crumb));
         }
 
         /// <summary>
@@ -72,6 +146,11 @@
         /// <returns>the response from the jenkins server</returns>
         public string Post(string command, string contentType, string postData)
         {
+            string crumb = this.crumb;
+            if (this.autoRetrieveCrumb)
+            {
+                crumb = RetrieveCrumb();
+            }
             return this.CallRequest(
                 new ContentTypeRequest(
                     new AuthorisedRequest(
@@ -79,7 +158,8 @@
                             new HttpRequest(this.url, command),
                             postData),
                         this.username,
-                        this.apiToken),
+                        this.apiToken,
+                        crumb),
                     contentType));
         }
 

--- a/src/JenkinsNetClient/JenkinsJob.cs
+++ b/src/JenkinsNetClient/JenkinsJob.cs
@@ -20,7 +20,8 @@
                   name,
                   string.Format("/checkJobName?value={0}", name),
                   string.Format("/createItem?name={0}&mode={1}", name, model),
-                  string.Format("/job/{0}/doDelete", name))
+                  string.Format("/job/{0}/doDelete", name),
+                  string.Format("/job/{0}/buildWithParameters", name))
         {
         }
 

--- a/src/JenkinsNetClient/JenkinsView.cs
+++ b/src/JenkinsNetClient/JenkinsView.cs
@@ -21,7 +21,8 @@
                   name,
                   string.Format("/viewExistsCheck?value={0}", name),
                   string.Format("/createView?name={0}&mode={1}", name, model),
-                  string.Format("/view/{0}/doDelete", name))
+                  string.Format("/view/{0}/doDelete", name),
+                  string.Format("/job/{0}/buildWithParameters", name))
         {
         }
 

--- a/src/JenkinsNetClient/Request/AuthorisedRequest.cs
+++ b/src/JenkinsNetClient/Request/AuthorisedRequest.cs
@@ -21,6 +21,11 @@
         private readonly string apiToken;
 
         /// <summary>
+        /// Holds the crumb
+        /// </summary>
+        private readonly string crumb;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="AuthorisedRequest"/> class.
         /// </summary>
         /// <param name="request">The request<see cref="IRequest"/></param>
@@ -31,6 +36,20 @@
             this.origin = request;
             this.username = username;
             this.apiToken = apiToken;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthorisedRequest"/> class.
+        /// </summary>
+        /// <param name="request">The request<see cref="IRequest"/></param>
+        /// <param name="username">The username<see cref="string"/></param>
+        /// <param name="apiToken">The API token<see cref="string"/></param>
+        public AuthorisedRequest(IRequest request, string username, string apiToken, string crumb)
+        {
+            this.origin = request;
+            this.username = username;
+            this.apiToken = apiToken;
+            this.crumb = crumb;
         }
 
         /// <summary>
@@ -47,6 +66,10 @@
                 byte[] byteCredentials = System.Text.UTF8Encoding.UTF8.GetBytes(mergedCredentials);
                 string base64Credentials = System.Convert.ToBase64String(byteCredentials);
                 req.Headers.Add("Authorization", "Basic " + base64Credentials);
+            }
+            if (!string.IsNullOrEmpty(this.crumb))
+            {
+                req.Headers.Add("Jenkins-Crumb", crumb);
             }
 
             return req;


### PR DESCRIPTION
# Features

## Crumbs
To provide compatability with Jenkins when ["Prevent Cross Site Request Forgery exploits" setting is enabled](https://wiki.jenkins.io/display/JENKINS/Remote+access+API#RemoteaccessAPI-CSRFProtection), allows using the crumb for requests both with and without username/token combo. Crumbs are obtained from the `/crumbIssuer/api/xml` API endpoint.

Example usage:
```vb
Dim connection As JenkinsConnection = New JenkinsConnection("http://jenkins-url", "jenkins-crumb")
```
or
```vb
Dim connection As JenkinsConnection = New JenkinsConnection("http://jenkins-url", "username", "token", "jenkins-crumb")
```

A "Jenkins-Crumb" header is added to the request when the crumb is specified.

## BuildWithParameters

A build can now be run by calling `BuildWithParameters` on a job.